### PR TITLE
change link from nsa.gov to www.nsa.gov

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Mitigating Web Shells
-This repository houses a number of tools and signatures to help defend networks against web shell malware. More information about web shells and the analytics used by the tools here is available in [NSA’s web shell mitigation guidance](https://nsa.gov/)
+This repository houses a number of tools and signatures to help defend networks against web shell malware. More information about web shells and the analytics used by the tools here is available in [NSA’s web shell mitigation guidance](https://www.nsa.gov/)
 
 **Table of Contents**
 - [Mitigating Web Shells](#mitigating-web-shells)


### PR DESCRIPTION
The link https://nsa.gov/ does not load since the NSA public web server is not configured to return content on the root domain. The link was updated to https://www.nsa.gov/.